### PR TITLE
Fix missing event data

### DIFF
--- a/scripts/nanobots.lua
+++ b/scripts/nanobots.lua
@@ -402,7 +402,9 @@ function Queue.build_tile_ghost(data)
                     {
                         robot = player.character,
                         positions = {position},
+                        surface_index = surface.index,
                         item = ptype,
+                        tile = tile,
                         tiles = {
                             {
                                 position = position,


### PR DESCRIPTION
When raising the on_robot_built_tile event, the tile and surface_index were missing and therefore causing an error message to be thrown in other mods (specifically seen in Space Exploration mod).